### PR TITLE
KubernetesManagedResources with more than one port fail

### DIFF
--- a/jcloud-core/src/main/java/io/jcloud/api/clients/KubectlClient.java
+++ b/jcloud-core/src/main/java/io/jcloud/api/clients/KubectlClient.java
@@ -101,7 +101,7 @@ public final class KubectlClient {
     public void expose(Service service, Integer port) {
         try {
             new Command(KUBECTL, "expose", "deployment", service.getName(), "--port=" + port,
-                    "--name=" + service.getName(), "-n", currentNamespace).runAndWait();
+                    "--name=" + createUniqueServiceName(service, port), "-n", currentNamespace).runAndWait();
         } catch (Exception e) {
             throw new RuntimeException("Service failed to be exposed.", e);
         }
@@ -211,7 +211,7 @@ public final class KubectlClient {
      * @return
      */
     public int port(Service service, int port) {
-        String serviceName = service.getName();
+        String serviceName = createUniqueServiceName(service, port);
         io.fabric8.kubernetes.api.model.Service serviceModel = client.services().withName(serviceName).get();
         if (serviceModel == null || serviceModel.getSpec() == null || serviceModel.getSpec().getPorts() == null) {
             throw new RuntimeException("Service " + serviceName + " not found");
@@ -365,6 +365,10 @@ public final class KubectlClient {
         return ThreadLocalRandom.current().ints(NAMESPACE_NAME_SIZE, 'a', 'z' + 1)
                 .collect(() -> new StringBuilder("ts-"), StringBuilder::appendCodePoint, StringBuilder::append)
                 .toString();
+    }
+
+    private String createUniqueServiceName(Service service, Integer port) {
+        return service.getName() + "-" + port;
     }
 
     class LocalPortForwardWrapper {


### PR DESCRIPTION
I am working on my own WildFly integration and noticed that if KubernetesManagedResource has more than one port, it fails.

Before this fix, I saw output like
```
[17:19:38.355] [INFO] kubectl: deployment.apps/wildflydeployment created 
[17:19:38.359] [INFO] Running command: kubectl expose deployment wildflydeployment --port=8080 --name=wildflydeployment -n ts-nmobrezzrt 
[17:19:38.420] [INFO] kubectl: service/wildflydeployment exposed 
[17:19:38.422] [INFO] Running command: kubectl expose deployment wildflydeployment --port=9990 --name=wildflydeployment -n ts-nmobrezzrt 
[17:19:38.473] [INFO] kubectl: Error from server (AlreadyExists): services "wildflydeployment" already exists 
```

It now gets past this point with the following output
```
[17:22:24.185] [INFO] kubectl: deployment.apps/wildflydeployment created 
[17:22:27.446] [INFO] Running command: kubectl expose deployment wildflydeployment --port=8080 --name=wildflydeployment-8080 -n ts-kpbzilyuoo 
[17:22:27.496] [INFO] kubectl: service/wildflydeployment-8080 exposed 
[17:22:33.468] [INFO] Running command: kubectl expose deployment wildflydeployment --port=9990 --name=wildflydeployment-9990 -n ts-kpbzilyuoo 
[17:22:33.533] [INFO] kubectl: service/wildflydeployment-9990 exposed 
[17:22:35.562] [INFO] Running command: kubectl scale deployment/wildflydeployment --replicas=1 -n ts-kpbzilyuoo 
[17:22:35.616] [INFO] kubectl: deployment.apps/wildflydeployment scaled 

```
